### PR TITLE
Check OPENAPI_SPEC_URL initialization timing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "open-api-mcp",
+  "name": "@yanhao-an/open-api-mcp",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "open-api-mcp",
+      "name": "@yanhao-an/open-api-mcp",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,7 @@ async function main() {
     const apiCaller = new ApiCaller(parser.getBaseUrl(), config);
 
     // Register tools
-    registerTools(server, parser, apiCaller);
+    registerTools(server, parser, apiCaller, loader);
 
     logger.info('MCP tools registered successfully');
 

--- a/src/openapi/parser.ts
+++ b/src/openapi/parser.ts
@@ -284,4 +284,16 @@ export class OpenAPIParser {
   getBaseUrl(): string {
     return this.baseUrl;
   }
+
+  /**
+   * Reload parser with a new OpenAPI document
+   */
+  reload(document: OpenAPIDocument): void {
+    logger.info('Reloading OpenAPI document...');
+    this.document = document;
+    this.endpoints = [];
+    this.baseUrl = this.extractBaseUrl();
+    this.indexEndpoints();
+    logger.info('OpenAPI document reloaded successfully');
+  }
 }


### PR DESCRIPTION
- Add reload() method to OpenAPIParser to update document and reindex endpoints
- Add refreshApiSpec MCP tool that refreshes OpenAPI spec from remote URL
- Update registerTools to accept OpenAPILoader parameter
- Allows updating API definitions without restarting the server

🤖 Generated with [Claude Code](https://claude.com/claude-code)